### PR TITLE
Fix compile error caused by rosidl_buffer introduction

### DIFF
--- a/src/bag2_to_image.cpp
+++ b/src/bag2_to_image.cpp
@@ -162,7 +162,8 @@ Bag2ToImageNode::Bag2ToImageNode(const rclcpp::NodeOptions & options)
 #endif
       deserializer_->deserialize(serialized_message, type_support, ros_message);
       try {
-        auto mat = cv::imdecode(cv::Mat(image->data), imdecode_flag_);
+        auto mat =
+          cv::imdecode(cv::Mat(static_cast<std::vector<uint8_t> &>(image->data)), imdecode_flag_);
 
         const size_t split_pos = image->format.find(';');
         std::string image_encoding = image->format.substr(0, split_pos);


### PR DESCRIPTION
Compiling this in rolling results in the following error:

    /build/bag2_to_image-release-release-rolling-bag2_to_image-0.1.1-1/src/bag2_to_image.cpp: In constructor 'bag2_to_image::Bag2ToImageNode::Bag2ToImageNode(const rclcpp::NodeOptions&)':
    /build/bag2_to_image-release-release-rolling-bag2_to_image-0.1.1-1/src/bag2_to_image.cpp:165:52: error: no matching function for call to 'cv::Mat::Mat(sensor_msgs::msg::CompressedImage_<std::allocator<void> >::_data_type&)'
      165 |         auto mat = cv::imdecode(cv::Mat(image->data), imdecode_flag_);
          |                                                    ^

These are caused by https://github.com/ros2/rosidl/pull/941 and followup PRs, which change the type of `uint8[]` message fields from `std::vector<uint8_t>` to `rosidl::Buffer<uint8_t>`. To maintain the previous functionality, explicit typecasting is needed. This causes invocation of the [conversion operator][1], which returns a reference to the underlying `std::vector`.

[1]: https://github.com/ros2/rosidl/blob/7c4e0f90f2979c16c906d65058fc7966360f52e1/rosidl_buffer/include/rosidl_buffer/buffer.hpp#L420